### PR TITLE
要約:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # os
-FROM ubuntu:22.04
+#FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # tools
 RUN apt-get -y update \
@@ -16,8 +17,8 @@ ENV LANG ja_JP.UTF-8
 ENV LANGUAGE ja_JP:ja
 
 # MySQL8
-RUN curl -OL https://dev.mysql.com/get/mysql-apt-config_0.8.24-1_all.deb
-RUN apt-get install -y ./mysql-apt-config_0.8.24-1_all.deb
+RUN curl -OL https://dev.mysql.com/get/mysql-apt-config_0.8.34-1_all.deb
+RUN apt-get install -y ./mysql-apt-config_0.8.34-1_all.deb
 RUN apt-get -y update \
  && apt-get install -y mysql-server
 VOLUME /var/lib/mysql

--- a/compose.yaml
+++ b/compose.yaml
@@ -39,7 +39,7 @@ networks:
 
 volumes:
   db1vol:
-    external: true
+    external: false
   db2vol:
-    external: true
+    external: false
 


### PR DESCRIPTION
Dockerfileとcompose.yamlの更新

修正内容:
- DockerfileでUbuntuのバージョンを22.04から24.04に変更
- MySQLのapt-configのバージョンを0.8.24から0.8.34に変更
- compose.yamlでボリュームのexternal設定をfalseに変更

修正によりどのように変わるのか:
新しいUbuntuバージョンとMySQLのapt-configを使用することで、最新の機能やセキュリティ修正が適用され、ボリュームがプロジェクト内のものに変更され、外部ボリュームの依存から解放される。